### PR TITLE
bumping worker disk sizes

### DIFF
--- a/bosh/cloud-config.yml
+++ b/bosh/cloud-config.yml
@@ -72,7 +72,7 @@ vm_types:
   cloud_properties:
     cpu: 8
     ram: 16_384
-    root_disk_size_gb: 164
+    root_disk_size_gb: 250
     root_disk_type: pd-ssd
     tags:
       - ((nat_traffic_tag))


### PR DESCRIPTION
- stemcell building gets hairy sometimes along with all of the
caching that concourse workers do. Need bigger disks and
the hope is that volumes / cached resources expire fast enough

Signed-off-by: Danny Berger <dberger@pivotal.io>